### PR TITLE
Portfolio updates: availability, LinkedIn fix, IAM collaboration project

### DIFF
--- a/portfolio/index.html
+++ b/portfolio/index.html
@@ -68,7 +68,7 @@
   <div class="stats-bar" role="region" aria-label="Portfolio statistics">
     <div class="container stats-grid">
       <div class="stat-item">
-        <span class="stat-number" data-target="5">0</span>
+        <span class="stat-number" data-target="6">0</span>
         <span class="stat-label">Security Projects</span>
       </div>
       <div class="stat-item">
@@ -397,6 +397,42 @@
           <div class="project-footer">
             <span class="test-count">36 unit tests</span>
             <a href="https://github.com/Rolly-M/Cloud-Security-Portfolio/tree/main/5%20-%20AWS_Macie_KMS"
+               target="_blank" rel="noopener noreferrer"
+               class="project-link">View project</a>
+          </div>
+        </article>
+
+        <!-- Project 6 — AWS IAM (Collaboration) -->
+        <article class="project-card fade-in delay-2">
+          <div class="project-header">
+            <div class="project-number">06</div>
+            <div class="project-title">
+              <small>Collaboration · <a href="https://github.com/SamsonIdowu" target="_blank" rel="noopener noreferrer" style="color:var(--blue)">SamsonIdowu</a></small>
+              AWS IAM Security Lab
+            </div>
+          </div>
+          <p class="project-desc">
+            Multi-account IAM security controls co-authored with
+            <a href="https://github.com/SamsonIdowu" target="_blank" rel="noopener noreferrer">SamsonIdowu</a>
+            at Innopolis University. Covers permission boundaries, Service Control Policies (SCPs),
+            IAM roles, and least-privilege policy design across AWS Organizations.
+          </p>
+          <ul class="project-highlights">
+            <li>Service Control Policies enforced at the Organizations level — denials no account-level policy can override</li>
+            <li>Permission boundaries limit the maximum permissions any role or user can self-assign</li>
+            <li>Least-privilege IAM policies scoped to specific resources, regions, and principal tags</li>
+            <li>CloudTrail + CloudWatch alarms for unauthorized API call detection and audit</li>
+          </ul>
+          <div class="project-tags">
+            <span class="tag tag-aws">IAM</span>
+            <span class="tag tag-aws">Organizations</span>
+            <span class="tag tag-aws">SCPs</span>
+            <span class="tag tag-aws">CloudTrail</span>
+            <span class="tag tag-iac">Terraform</span>
+          </div>
+          <div class="project-footer">
+            <span class="test-count">Collaboration project</span>
+            <a href="https://github.com/SNE22-INNOPOLIS/AWS-IAM"
                target="_blank" rel="noopener noreferrer"
                class="project-link">View project</a>
           </div>


### PR DESCRIPTION
## Summary

- Updated availability text to "Calgary, Remote Canada or Remote EU" in hero badge and contact section
- Fixed LinkedIn URL to `https://www.linkedin.com/in/rolly-mougoue/` (corrected everywhere it appeared)
- Added 6th project card: **AWS IAM Security Lab** — collaboration with [SamsonIdowu](https://github.com/SamsonIdowu) at Innopolis University ([SNE22-INNOPOLIS/AWS-IAM](https://github.com/SNE22-INNOPOLIS/AWS-IAM)), covering SCPs, permission boundaries, least-privilege IAM, and CloudTrail alerting
- Updated stats counter to reflect 6 security projects
- Added Netlify deployment config (`netlify.toml`) with security headers (CSP, X-Frame-Options, etc.) and asset caching rules
- Added `portfolio/_redirects` for SPA routing fallback

## Test plan

- [ ] Verify hero badge shows updated availability text
- [ ] Verify all LinkedIn links navigate to the correct profile
- [ ] Verify Project 06 (IAM Security Lab) card renders correctly with collaboration credit
- [ ] Verify "View project" link on Project 06 opens the correct GitHub repo
- [ ] Verify stats counter animates to 6
- [ ] Check Netlify deploy preview — no CSP violations in browser console

---
_Generated by [Claude Code](https://claude.ai/code/session_01Bv3qLnk3bb4U3rPD48WCmS)_