### PR TITLE
Add metrics counters and skill matrix to home page

### DIFF
--- a/portfolio/css/style.css
+++ b/portfolio/css/style.css
@@ -724,6 +724,124 @@ button { font-family: var(--font); }
   color: var(--green);
 }
 
+/* ── Metrics ─────────────────────────────────────────────────── */
+.metrics-section {
+  padding: 52px 0;
+  border-top: 1px solid var(--border);
+  position: relative;
+  z-index: 1;
+}
+.metrics-grid {
+  display: grid;
+  grid-template-columns: repeat(5, 1fr);
+  gap: 14px;
+}
+.metric-card {
+  background: linear-gradient(145deg, rgba(0,210,255,0.04) 0%, rgba(255,255,255,0.01) 100%);
+  border: 1px solid var(--border);
+  border-radius: var(--r-lg);
+  padding: 28px 16px;
+  text-align: center;
+  transition: border-color .25s, box-shadow .25s, transform .25s;
+  position: relative;
+  overflow: hidden;
+}
+.metric-card::before {
+  content: '';
+  position: absolute;
+  top: 0; left: 0; right: 0;
+  height: 2px;
+  background: linear-gradient(90deg, transparent, rgba(0,210,255,0.5), transparent);
+  opacity: 0;
+  transition: opacity .25s;
+}
+.metric-card:hover {
+  border-color: rgba(0,210,255,0.30);
+  box-shadow: 0 10px 36px rgba(0,210,255,0.08);
+  transform: translateY(-2px);
+}
+.metric-card:hover::before { opacity: 1; }
+.metric-num {
+  font-size: 46px;
+  font-weight: 800;
+  line-height: 1;
+  background: linear-gradient(120deg, #00d2ff 0%, #b8eeff 100%);
+  -webkit-background-clip: text;
+  -webkit-text-fill-color: transparent;
+  background-clip: text;
+  margin-bottom: 12px;
+  font-variant-numeric: tabular-nums;
+}
+.metric-label {
+  font-size: 10.5px;
+  font-weight: 700;
+  color: var(--text-dim);
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  line-height: 1.55;
+}
+
+/* ── Skill Matrix ─────────────────────────────────────────────── */
+.skills-section { padding: 80px 0 96px; }
+.sm-header { margin-bottom: 44px; }
+.skill-matrix {
+  display: grid;
+  grid-template-columns: repeat(2, 1fr);
+  gap: 18px;
+}
+.skill-category {
+  background: linear-gradient(145deg, rgba(255,255,255,0.03) 0%, rgba(255,255,255,0.01) 100%);
+  border: 1px solid var(--border);
+  border-radius: var(--r-lg);
+  padding: 22px 26px 18px;
+  transition: border-color .25s;
+}
+.skill-category:hover { border-color: rgba(0,210,255,0.16); }
+.skill-cat-title {
+  font-size: 10px;
+  font-weight: 800;
+  letter-spacing: 0.14em;
+  color: var(--accent);
+  text-transform: uppercase;
+  margin-bottom: 16px;
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+.skill-cat-title svg { flex-shrink: 0; opacity: 0.85; }
+.skill-rows { display: flex; flex-direction: column; }
+.skill-row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 8px 0;
+  border-bottom: 1px solid rgba(255,255,255,0.04);
+  transition: background .15s;
+}
+.skill-row:last-child { border-bottom: none; }
+.skill-name {
+  font-size: 12.5px;
+  color: var(--text-muted);
+  transition: color .15s;
+}
+.skill-row:hover .skill-name { color: var(--text); }
+.skill-dots { display: flex; gap: 5px; align-items: center; }
+.skill-dot {
+  width: 9px; height: 9px;
+  border-radius: 50%;
+  border: 1.5px solid rgba(0,210,255,0.20);
+  background: transparent;
+  transition: box-shadow .2s;
+}
+.skill-dot.on {
+  background: var(--accent);
+  border-color: var(--accent);
+  box-shadow: 0 0 5px rgba(0,210,255,0.50);
+}
+.skill-row:hover .skill-dot.on {
+  box-shadow: 0 0 9px rgba(0,210,255,0.75);
+}
+
 /* ── Footer ──────────────────────────────────────────────────── */
 footer {
   position: relative;

--- a/portfolio/index.html
+++ b/portfolio/index.html
@@ -101,6 +101,200 @@
     </section>
   </main>
 
+  <!-- ── Metrics ────────────────────────────────────────────── -->
+  <section class="metrics-section" aria-label="Portfolio metrics">
+    <div class="container">
+      <div class="metrics-grid">
+
+        <div class="metric-card fade-in">
+          <div class="metric-num" data-target="6">0</div>
+          <div class="metric-label">Security<br>Projects</div>
+        </div>
+
+        <div class="metric-card fade-in d1">
+          <div class="metric-num" data-target="154" data-suffix="+">0</div>
+          <div class="metric-label">Unit Tests<br>Passing</div>
+        </div>
+
+        <div class="metric-card fade-in d2">
+          <div class="metric-num" data-target="3">0</div>
+          <div class="metric-label">Certifications<br>Earned</div>
+        </div>
+
+        <div class="metric-card fade-in d1">
+          <div class="metric-num" data-target="100" data-suffix="%">0</div>
+          <div class="metric-label">Terraform<br>IaC Coverage</div>
+        </div>
+
+        <div class="metric-card fade-in d2">
+          <div class="metric-num" data-target="5">0</div>
+          <div class="metric-label">AWS Services<br>Automated</div>
+        </div>
+
+      </div>
+    </div>
+  </section>
+
+  <!-- ── Skill Matrix ───────────────────────────────────────── -->
+  <section class="skills-section page-section" aria-label="Skill matrix">
+    <div class="container">
+
+      <div class="sm-header fade-in">
+        <span class="section-label">Expertise</span>
+        <h2 class="section-title">Skill Matrix</h2>
+        <p class="section-desc">Proficiency across AWS security services, infrastructure tooling, and engineering practices.</p>
+      </div>
+
+      <div class="skill-matrix">
+
+        <!-- AWS Security Services -->
+        <div class="skill-category fade-in d1">
+          <h3 class="skill-cat-title">
+            <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2" aria-hidden="true"><path d="M12 22s8-4 8-10V5l-8-3-8 3v7c0 6 8 10 8 10z"/></svg>
+            AWS Security Services
+          </h3>
+          <div class="skill-rows">
+            <div class="skill-row">
+              <span class="skill-name">IAM &amp; SCPs</span>
+              <div class="skill-dots"><span class="skill-dot on"></span><span class="skill-dot on"></span><span class="skill-dot on"></span><span class="skill-dot on"></span><span class="skill-dot on"></span></div>
+            </div>
+            <div class="skill-row">
+              <span class="skill-name">GuardDuty</span>
+              <div class="skill-dots"><span class="skill-dot on"></span><span class="skill-dot on"></span><span class="skill-dot on"></span><span class="skill-dot on"></span><span class="skill-dot on"></span></div>
+            </div>
+            <div class="skill-row">
+              <span class="skill-name">WAFv2</span>
+              <div class="skill-dots"><span class="skill-dot on"></span><span class="skill-dot on"></span><span class="skill-dot on"></span><span class="skill-dot on"></span><span class="skill-dot on"></span></div>
+            </div>
+            <div class="skill-row">
+              <span class="skill-name">Macie v2</span>
+              <div class="skill-dots"><span class="skill-dot on"></span><span class="skill-dot on"></span><span class="skill-dot on"></span><span class="skill-dot on"></span><span class="skill-dot"></span></div>
+            </div>
+            <div class="skill-row">
+              <span class="skill-name">Inspector v2</span>
+              <div class="skill-dots"><span class="skill-dot on"></span><span class="skill-dot on"></span><span class="skill-dot on"></span><span class="skill-dot on"></span><span class="skill-dot"></span></div>
+            </div>
+            <div class="skill-row">
+              <span class="skill-name">KMS / CloudTrail</span>
+              <div class="skill-dots"><span class="skill-dot on"></span><span class="skill-dot on"></span><span class="skill-dot on"></span><span class="skill-dot on"></span><span class="skill-dot on"></span></div>
+            </div>
+            <div class="skill-row">
+              <span class="skill-name">Security Hub</span>
+              <div class="skill-dots"><span class="skill-dot on"></span><span class="skill-dot on"></span><span class="skill-dot on"></span><span class="skill-dot"></span><span class="skill-dot"></span></div>
+            </div>
+          </div>
+        </div>
+
+        <!-- Cloud Infrastructure -->
+        <div class="skill-category fade-in d2">
+          <h3 class="skill-cat-title">
+            <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2" aria-hidden="true"><rect x="2" y="3" width="20" height="14" rx="2"/><path d="M8 21h8M12 17v4"/></svg>
+            Cloud Infrastructure
+          </h3>
+          <div class="skill-rows">
+            <div class="skill-row">
+              <span class="skill-name">Terraform</span>
+              <div class="skill-dots"><span class="skill-dot on"></span><span class="skill-dot on"></span><span class="skill-dot on"></span><span class="skill-dot on"></span><span class="skill-dot on"></span></div>
+            </div>
+            <div class="skill-row">
+              <span class="skill-name">Lambda</span>
+              <div class="skill-dots"><span class="skill-dot on"></span><span class="skill-dot on"></span><span class="skill-dot on"></span><span class="skill-dot on"></span><span class="skill-dot on"></span></div>
+            </div>
+            <div class="skill-row">
+              <span class="skill-name">EventBridge</span>
+              <div class="skill-dots"><span class="skill-dot on"></span><span class="skill-dot on"></span><span class="skill-dot on"></span><span class="skill-dot on"></span><span class="skill-dot on"></span></div>
+            </div>
+            <div class="skill-row">
+              <span class="skill-name">VPC / NACLs</span>
+              <div class="skill-dots"><span class="skill-dot on"></span><span class="skill-dot on"></span><span class="skill-dot on"></span><span class="skill-dot on"></span><span class="skill-dot on"></span></div>
+            </div>
+            <div class="skill-row">
+              <span class="skill-name">API Gateway</span>
+              <div class="skill-dots"><span class="skill-dot on"></span><span class="skill-dot on"></span><span class="skill-dot on"></span><span class="skill-dot on"></span><span class="skill-dot"></span></div>
+            </div>
+            <div class="skill-row">
+              <span class="skill-name">CloudWatch / SNS</span>
+              <div class="skill-dots"><span class="skill-dot on"></span><span class="skill-dot on"></span><span class="skill-dot on"></span><span class="skill-dot on"></span><span class="skill-dot"></span></div>
+            </div>
+            <div class="skill-row">
+              <span class="skill-name">S3 / EC2</span>
+              <div class="skill-dots"><span class="skill-dot on"></span><span class="skill-dot on"></span><span class="skill-dot on"></span><span class="skill-dot on"></span><span class="skill-dot on"></span></div>
+            </div>
+          </div>
+        </div>
+
+        <!-- Languages & Testing -->
+        <div class="skill-category fade-in d1">
+          <h3 class="skill-cat-title">
+            <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2" aria-hidden="true"><polyline points="16 18 22 12 16 6"/><polyline points="8 6 2 12 8 18"/></svg>
+            Languages &amp; Testing
+          </h3>
+          <div class="skill-rows">
+            <div class="skill-row">
+              <span class="skill-name">Python 3.11</span>
+              <div class="skill-dots"><span class="skill-dot on"></span><span class="skill-dot on"></span><span class="skill-dot on"></span><span class="skill-dot on"></span><span class="skill-dot"></span></div>
+            </div>
+            <div class="skill-row">
+              <span class="skill-name">pytest</span>
+              <div class="skill-dots"><span class="skill-dot on"></span><span class="skill-dot on"></span><span class="skill-dot on"></span><span class="skill-dot on"></span><span class="skill-dot on"></span></div>
+            </div>
+            <div class="skill-row">
+              <span class="skill-name">moto (AWS mocking)</span>
+              <div class="skill-dots"><span class="skill-dot on"></span><span class="skill-dot on"></span><span class="skill-dot on"></span><span class="skill-dot on"></span><span class="skill-dot on"></span></div>
+            </div>
+            <div class="skill-row">
+              <span class="skill-name">boto3</span>
+              <div class="skill-dots"><span class="skill-dot on"></span><span class="skill-dot on"></span><span class="skill-dot on"></span><span class="skill-dot on"></span><span class="skill-dot on"></span></div>
+            </div>
+            <div class="skill-row">
+              <span class="skill-name">Git / GitHub Actions</span>
+              <div class="skill-dots"><span class="skill-dot on"></span><span class="skill-dot on"></span><span class="skill-dot on"></span><span class="skill-dot on"></span><span class="skill-dot"></span></div>
+            </div>
+            <div class="skill-row">
+              <span class="skill-name">bash</span>
+              <div class="skill-dots"><span class="skill-dot on"></span><span class="skill-dot on"></span><span class="skill-dot on"></span><span class="skill-dot"></span><span class="skill-dot"></span></div>
+            </div>
+          </div>
+        </div>
+
+        <!-- Security Practices -->
+        <div class="skill-category fade-in d2">
+          <h3 class="skill-cat-title">
+            <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2" aria-hidden="true"><circle cx="12" cy="12" r="10"/><line x1="12" y1="8" x2="12" y2="12"/><line x1="12" y1="16" x2="12.01" y2="16"/></svg>
+            Security Practices
+          </h3>
+          <div class="skill-rows">
+            <div class="skill-row">
+              <span class="skill-name">Threat Detection</span>
+              <div class="skill-dots"><span class="skill-dot on"></span><span class="skill-dot on"></span><span class="skill-dot on"></span><span class="skill-dot on"></span><span class="skill-dot on"></span></div>
+            </div>
+            <div class="skill-row">
+              <span class="skill-name">Auto-Remediation</span>
+              <div class="skill-dots"><span class="skill-dot on"></span><span class="skill-dot on"></span><span class="skill-dot on"></span><span class="skill-dot on"></span><span class="skill-dot on"></span></div>
+            </div>
+            <div class="skill-row">
+              <span class="skill-name">Defense in Depth</span>
+              <div class="skill-dots"><span class="skill-dot on"></span><span class="skill-dot on"></span><span class="skill-dot on"></span><span class="skill-dot on"></span><span class="skill-dot on"></span></div>
+            </div>
+            <div class="skill-row">
+              <span class="skill-name">Least Privilege IAM</span>
+              <div class="skill-dots"><span class="skill-dot on"></span><span class="skill-dot on"></span><span class="skill-dot on"></span><span class="skill-dot on"></span><span class="skill-dot on"></span></div>
+            </div>
+            <div class="skill-row">
+              <span class="skill-name">Incident Response</span>
+              <div class="skill-dots"><span class="skill-dot on"></span><span class="skill-dot on"></span><span class="skill-dot on"></span><span class="skill-dot on"></span><span class="skill-dot"></span></div>
+            </div>
+            <div class="skill-row">
+              <span class="skill-name">Vulnerability Mgmt</span>
+              <div class="skill-dots"><span class="skill-dot on"></span><span class="skill-dot on"></span><span class="skill-dot on"></span><span class="skill-dot on"></span><span class="skill-dot"></span></div>
+            </div>
+          </div>
+        </div>
+
+      </div><!-- /skill-matrix -->
+    </div>
+  </section>
+
   <!-- ── Footer ─────────────────────────────────────────────── -->
   <footer>
     <div class="container footer-inner">

--- a/portfolio/js/main.js
+++ b/portfolio/js/main.js
@@ -217,13 +217,13 @@ document.addEventListener('DOMContentLoaded', function () {
 /* ── Animated counters ───────────────────────────────────────── */
 function animateCounter(el) {
   var target = parseInt(el.dataset.target, 10);
+  var suffix = el.dataset.suffix || '';
   var dur = 1600, startTime = performance.now();
   (function step(now) {
     var p = Math.min((now - startTime) / dur, 1);
     var eased = 1 - Math.pow(1 - p, 3);
-    el.textContent = Math.floor(eased * target);
+    el.textContent = Math.floor(eased * target) + (p < 1 ? '' : suffix);
     if (p < 1) requestAnimationFrame(step);
-    else el.textContent = target;
   })(startTime);
 }
 
@@ -235,5 +235,6 @@ var counterObs = new IntersectionObserver(function (entries) {
   });
 }, { threshold: 0.2 });
 
-var statsRow = document.querySelector('.stats-row');
-if (statsRow) counterObs.observe(statsRow);
+document.querySelectorAll('.stats-row, .metrics-grid').forEach(function (el) {
+  counterObs.observe(el);
+});


### PR DESCRIPTION
Adds an animated 5-card metrics strip (Security Projects, Unit Tests, Certifications, IaC Coverage, AWS Services) and a 2×2 skill dot-matrix grid to the home page. Counter animation now supports data-suffix so values like 154+ and 100% render correctly on completion.


Claude-Session: https://claude.ai/code/session_01Bv3qLnk3bb4U3rPD48WCmS