### PR TITLE
Redesign metrics and skills sections with compelling visuals

### DIFF
--- a/portfolio/css/style.css
+++ b/portfolio/css/style.css
@@ -726,120 +726,207 @@ button { font-family: var(--font); }
 
 /* ── Metrics ─────────────────────────────────────────────────── */
 .metrics-section {
-  padding: 52px 0;
-  border-top: 1px solid var(--border);
+  padding: 96px 0 104px;
   position: relative;
   z-index: 1;
+  overflow: hidden;
 }
+.metrics-section::before {
+  content: '';
+  position: absolute;
+  top: 0; left: 50%;
+  transform: translateX(-50%);
+  width: 70%; max-width: 720px;
+  height: 1px;
+  background: linear-gradient(90deg, transparent, rgba(0,210,255,0.35), transparent);
+}
+/* ambient sweep animation */
+.metrics-section::after {
+  content: '';
+  position: absolute;
+  top: 0; left: -100%;
+  width: 60%; height: 100%;
+  background: linear-gradient(90deg, transparent, rgba(0,210,255,0.015), transparent);
+  animation: metricsSweep 7s ease-in-out infinite;
+  pointer-events: none;
+}
+@keyframes metricsSweep {
+  0%   { left: -60%; }
+  100% { left: 160%; }
+}
+.metrics-hd {
+  text-align: center;
+  margin-bottom: 64px;
+}
+.metrics-title { justify-content: center; }
+.metrics-desc { text-align: center; max-width: 520px; margin: 0 auto; }
 .metrics-grid {
   display: grid;
   grid-template-columns: repeat(5, 1fr);
   gap: 14px;
 }
+
+/* color variants */
+.mc-cyan   { --mc: #00d2ff; }
+.mc-green  { --mc: #22c55e; }
+.mc-orange { --mc: #f0883e; }
+.mc-purple { --mc: #bc8cff; }
+.mc-blue   { --mc: #60a5fa; }
+
 .metric-card {
-  background: linear-gradient(145deg, rgba(0,210,255,0.04) 0%, rgba(255,255,255,0.01) 100%);
-  border: 1px solid var(--border);
-  border-radius: var(--r-lg);
-  padding: 28px 16px;
+  border-radius: 18px;
+  padding: 36px 16px 30px;
   text-align: center;
-  transition: border-color .25s, box-shadow .25s, transform .25s;
   position: relative;
   overflow: hidden;
+  border: 1px solid rgba(255,255,255,0.07);
+  background: rgba(255,255,255,0.025);
+  transition: transform .35s, border-color .35s, box-shadow .35s;
+  cursor: default;
 }
+/* radial glow from top (hidden until hover) */
+.metric-card::after {
+  content: '';
+  position: absolute;
+  top: -40%; left: 50%;
+  transform: translateX(-50%);
+  width: 180%; height: 200%;
+  border-radius: 50%;
+  background: radial-gradient(ellipse at top, var(--mc) 0%, transparent 60%);
+  opacity: 0;
+  transition: opacity .4s;
+  pointer-events: none;
+}
+.metric-card:hover::after { opacity: 0.07; }
+/* bottom accent line */
 .metric-card::before {
   content: '';
   position: absolute;
-  top: 0; left: 0; right: 0;
+  bottom: 0; left: 10%; right: 10%;
   height: 2px;
-  background: linear-gradient(90deg, transparent, rgba(0,210,255,0.5), transparent);
-  opacity: 0;
-  transition: opacity .25s;
+  border-radius: 1px;
+  background: linear-gradient(90deg, transparent, var(--mc), transparent);
+  opacity: 0.45;
+  transition: opacity .35s, left .35s, right .35s;
 }
 .metric-card:hover {
-  border-color: rgba(0,210,255,0.30);
-  box-shadow: 0 10px 36px rgba(0,210,255,0.08);
-  transform: translateY(-2px);
+  transform: translateY(-6px);
+  border-color: var(--mc);
+  box-shadow: 0 0 0 1px var(--mc),
+              0 24px 60px rgba(0,0,0,0.45),
+              0 0 50px rgba(0,0,0,0.2);
 }
-.metric-card:hover::before { opacity: 1; }
-.metric-num {
-  font-size: 46px;
-  font-weight: 800;
+.metric-card:hover::before { opacity: 1; left: 0; right: 0; }
+
+.mc-icon {
+  width: 50px; height: 50px;
+  margin: 0 auto 22px;
+  border-radius: 14px;
+  display: flex; align-items: center; justify-content: center;
+  color: var(--mc);
+  transition: transform .3s;
+}
+.mc-cyan   .mc-icon { background: rgba(0,210,255,0.10);  border: 1px solid rgba(0,210,255,0.25); }
+.mc-green  .mc-icon { background: rgba(34,197,94,0.10);  border: 1px solid rgba(34,197,94,0.25); }
+.mc-orange .mc-icon { background: rgba(240,136,62,0.10); border: 1px solid rgba(240,136,62,0.25); }
+.mc-purple .mc-icon { background: rgba(188,140,255,0.10);border: 1px solid rgba(188,140,255,0.25); }
+.mc-blue   .mc-icon { background: rgba(96,165,250,0.10); border: 1px solid rgba(96,165,250,0.25); }
+.mc-icon svg { width: 22px; height: 22px; }
+.metric-card:hover .mc-icon { transform: scale(1.12); }
+
+.mc-num {
+  font-size: 54px;
+  font-weight: 900;
   line-height: 1;
-  background: linear-gradient(120deg, #00d2ff 0%, #b8eeff 100%);
-  -webkit-background-clip: text;
-  -webkit-text-fill-color: transparent;
-  background-clip: text;
-  margin-bottom: 12px;
+  color: var(--mc);
+  margin-bottom: 10px;
   font-variant-numeric: tabular-nums;
+  letter-spacing: -0.025em;
+  text-shadow: 0 0 32px var(--mc);
 }
-.metric-label {
-  font-size: 10.5px;
+.mc-lbl {
+  font-size: 10px;
   font-weight: 700;
   color: var(--text-dim);
-  letter-spacing: 0.08em;
+  letter-spacing: 0.10em;
   text-transform: uppercase;
-  line-height: 1.55;
+  line-height: 1.65;
 }
 
 /* ── Skill Matrix ─────────────────────────────────────────────── */
-.skills-section { padding: 80px 0 96px; }
-.sm-header { margin-bottom: 44px; }
+.skills-section {
+  padding: 80px 0 100px;
+  position: relative;
+  z-index: 1;
+}
+.sm-header { margin-bottom: 52px; }
 .skill-matrix {
   display: grid;
   grid-template-columns: repeat(2, 1fr);
   gap: 18px;
 }
 .skill-category {
-  background: linear-gradient(145deg, rgba(255,255,255,0.03) 0%, rgba(255,255,255,0.01) 100%);
-  border: 1px solid var(--border);
+  background: rgba(255,255,255,0.02);
+  border: 1px solid rgba(255,255,255,0.07);
+  border-left: 3px solid var(--cat-c, var(--accent));
   border-radius: var(--r-lg);
-  padding: 22px 26px 18px;
-  transition: border-color .25s;
+  padding: 26px 28px 20px;
+  transition: border-color .25s, box-shadow .25s;
 }
-.skill-category:hover { border-color: rgba(0,210,255,0.16); }
+.skill-category:hover {
+  box-shadow: 0 0 0 1px rgba(var(--cat-rgb, 0,210,255), 0.12),
+              0 12px 40px rgba(0,0,0,0.3);
+}
 .skill-cat-title {
   font-size: 10px;
   font-weight: 800;
   letter-spacing: 0.14em;
-  color: var(--accent);
+  color: var(--cat-c, var(--accent));
   text-transform: uppercase;
-  margin-bottom: 16px;
+  margin-bottom: 20px;
   display: flex;
   align-items: center;
-  gap: 8px;
+  gap: 10px;
 }
-.skill-cat-title svg { flex-shrink: 0; opacity: 0.85; }
+.sct-icon {
+  width: 28px; height: 28px;
+  border-radius: 8px;
+  background: rgba(var(--cat-rgb, 0,210,255), 0.10);
+  display: flex; align-items: center; justify-content: center;
+  flex-shrink: 0;
+}
+.sct-icon svg { width: 14px; height: 14px; stroke: var(--cat-c, var(--accent)); }
 .skill-rows { display: flex; flex-direction: column; }
 .skill-row {
   display: flex;
   align-items: center;
-  justify-content: space-between;
-  padding: 8px 0;
+  gap: 14px;
+  padding: 9px 0;
   border-bottom: 1px solid rgba(255,255,255,0.04);
-  transition: background .15s;
 }
 .skill-row:last-child { border-bottom: none; }
 .skill-name {
+  flex: 0 0 148px;
   font-size: 12.5px;
   color: var(--text-muted);
   transition: color .15s;
+  white-space: nowrap;
 }
 .skill-row:hover .skill-name { color: var(--text); }
-.skill-dots { display: flex; gap: 5px; align-items: center; }
-.skill-dot {
-  width: 9px; height: 9px;
-  border-radius: 50%;
-  border: 1.5px solid rgba(0,210,255,0.20);
-  background: transparent;
-  transition: box-shadow .2s;
+.skill-track {
+  flex: 1;
+  height: 5px;
+  background: rgba(255,255,255,0.07);
+  border-radius: 3px;
+  overflow: hidden;
 }
-.skill-dot.on {
-  background: var(--accent);
-  border-color: var(--accent);
-  box-shadow: 0 0 5px rgba(0,210,255,0.50);
-}
-.skill-row:hover .skill-dot.on {
-  box-shadow: 0 0 9px rgba(0,210,255,0.75);
+.skill-fill {
+  height: 100%;
+  width: 0;
+  border-radius: 3px;
+  background: linear-gradient(90deg, var(--cat-c, var(--accent)), rgba(255,255,255,0.6));
+  transition: width 1.1s cubic-bezier(0.4, 0, 0.2, 1);
+  box-shadow: 0 0 6px var(--cat-c, var(--accent));
 }
 
 /* ── Footer ──────────────────────────────────────────────────── */
@@ -927,9 +1014,16 @@ footer {
   .project-card.featured { grid-template-columns: 1fr; }
   .stats-row { gap: 24px; }
   .footer-inner { flex-direction: column; text-align: center; }
+  .metrics-grid { grid-template-columns: repeat(2, 1fr); }
+  .metrics-grid .metric-card:nth-child(5) { grid-column: span 2; }
+  .skill-matrix { grid-template-columns: 1fr; }
+  .skill-name { flex: 0 0 120px; }
 }
 
 @media (max-width: 500px) {
   .hero-name { font-size: 34px; }
   .btn { padding: 10px 18px; font-size: 13px; }
+  .metrics-grid { grid-template-columns: 1fr; }
+  .metrics-grid .metric-card:nth-child(5) { grid-column: auto; }
+  .mc-num { font-size: 44px; }
 }

--- a/portfolio/index.html
+++ b/portfolio/index.html
@@ -104,31 +104,55 @@
   <!-- ── Metrics ────────────────────────────────────────────── -->
   <section class="metrics-section" aria-label="Portfolio metrics">
     <div class="container">
+
+      <div class="metrics-hd fade-in">
+        <span class="section-label">By the Numbers</span>
+        <h2 class="section-title metrics-title">Built to a Standard</h2>
+        <p class="section-desc metrics-desc">
+          Every project ships with Terraform infrastructure and a full test suite. No exceptions.
+        </p>
+      </div>
+
       <div class="metrics-grid">
 
-        <div class="metric-card fade-in">
-          <div class="metric-num" data-target="6">0</div>
-          <div class="metric-label">Security<br>Projects</div>
+        <div class="metric-card mc-cyan fade-in">
+          <div class="mc-icon" aria-hidden="true">
+            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5"><path d="M12 22s8-4 8-10V5l-8-3-8 3v7c0 6 8 10 8 10z"/></svg>
+          </div>
+          <div class="mc-num" data-target="6">0</div>
+          <div class="mc-lbl">Security<br>Projects</div>
         </div>
 
-        <div class="metric-card fade-in d1">
-          <div class="metric-num" data-target="154" data-suffix="+">0</div>
-          <div class="metric-label">Unit Tests<br>Passing</div>
+        <div class="metric-card mc-green fade-in d1">
+          <div class="mc-icon" aria-hidden="true">
+            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5"><polyline points="20 6 9 17 4 12"/></svg>
+          </div>
+          <div class="mc-num" data-target="154" data-suffix="+">0</div>
+          <div class="mc-lbl">Unit Tests<br>Passing</div>
         </div>
 
-        <div class="metric-card fade-in d2">
-          <div class="metric-num" data-target="3">0</div>
-          <div class="metric-label">Certifications<br>Earned</div>
+        <div class="metric-card mc-orange fade-in d2">
+          <div class="mc-icon" aria-hidden="true">
+            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5"><circle cx="12" cy="8" r="6"/><path d="M15.477 12.89L17 22l-5-3-5 3 1.523-9.11"/></svg>
+          </div>
+          <div class="mc-num" data-target="3">0</div>
+          <div class="mc-lbl">Certifications<br>Earned</div>
         </div>
 
-        <div class="metric-card fade-in d1">
-          <div class="metric-num" data-target="100" data-suffix="%">0</div>
-          <div class="metric-label">Terraform<br>IaC Coverage</div>
+        <div class="metric-card mc-purple fade-in d1">
+          <div class="mc-icon" aria-hidden="true">
+            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5"><polyline points="16 18 22 12 16 6"/><polyline points="8 6 2 12 8 18"/></svg>
+          </div>
+          <div class="mc-num" data-target="100" data-suffix="%">0</div>
+          <div class="mc-lbl">Terraform<br>IaC Coverage</div>
         </div>
 
-        <div class="metric-card fade-in d2">
-          <div class="metric-num" data-target="5">0</div>
-          <div class="metric-label">AWS Services<br>Automated</div>
+        <div class="metric-card mc-blue fade-in d2">
+          <div class="mc-icon" aria-hidden="true">
+            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5"><path d="M18 20V10M12 20V4M6 20v-6"/></svg>
+          </div>
+          <div class="mc-num" data-target="5">0</div>
+          <div class="mc-lbl">AWS Services<br>Automated</div>
         </div>
 
       </div>
@@ -136,7 +160,7 @@
   </section>
 
   <!-- ── Skill Matrix ───────────────────────────────────────── -->
-  <section class="skills-section page-section" aria-label="Skill matrix">
+  <section class="skills-section" aria-label="Skill matrix">
     <div class="container">
 
       <div class="sm-header fade-in">
@@ -147,146 +171,154 @@
 
       <div class="skill-matrix">
 
-        <!-- AWS Security Services -->
-        <div class="skill-category fade-in d1">
+        <!-- AWS Security Services — cyan -->
+        <div class="skill-category fade-in d1" style="--cat-c:#00d2ff;--cat-rgb:0,210,255">
           <h3 class="skill-cat-title">
-            <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2" aria-hidden="true"><path d="M12 22s8-4 8-10V5l-8-3-8 3v7c0 6 8 10 8 10z"/></svg>
+            <span class="sct-icon" aria-hidden="true">
+              <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M12 22s8-4 8-10V5l-8-3-8 3v7c0 6 8 10 8 10z"/></svg>
+            </span>
             AWS Security Services
           </h3>
           <div class="skill-rows">
             <div class="skill-row">
               <span class="skill-name">IAM &amp; SCPs</span>
-              <div class="skill-dots"><span class="skill-dot on"></span><span class="skill-dot on"></span><span class="skill-dot on"></span><span class="skill-dot on"></span><span class="skill-dot on"></span></div>
+              <div class="skill-track"><div class="skill-fill" data-pct="100"></div></div>
             </div>
             <div class="skill-row">
               <span class="skill-name">GuardDuty</span>
-              <div class="skill-dots"><span class="skill-dot on"></span><span class="skill-dot on"></span><span class="skill-dot on"></span><span class="skill-dot on"></span><span class="skill-dot on"></span></div>
+              <div class="skill-track"><div class="skill-fill" data-pct="100"></div></div>
             </div>
             <div class="skill-row">
               <span class="skill-name">WAFv2</span>
-              <div class="skill-dots"><span class="skill-dot on"></span><span class="skill-dot on"></span><span class="skill-dot on"></span><span class="skill-dot on"></span><span class="skill-dot on"></span></div>
+              <div class="skill-track"><div class="skill-fill" data-pct="100"></div></div>
             </div>
             <div class="skill-row">
               <span class="skill-name">Macie v2</span>
-              <div class="skill-dots"><span class="skill-dot on"></span><span class="skill-dot on"></span><span class="skill-dot on"></span><span class="skill-dot on"></span><span class="skill-dot"></span></div>
+              <div class="skill-track"><div class="skill-fill" data-pct="85"></div></div>
             </div>
             <div class="skill-row">
               <span class="skill-name">Inspector v2</span>
-              <div class="skill-dots"><span class="skill-dot on"></span><span class="skill-dot on"></span><span class="skill-dot on"></span><span class="skill-dot on"></span><span class="skill-dot"></span></div>
+              <div class="skill-track"><div class="skill-fill" data-pct="85"></div></div>
             </div>
             <div class="skill-row">
               <span class="skill-name">KMS / CloudTrail</span>
-              <div class="skill-dots"><span class="skill-dot on"></span><span class="skill-dot on"></span><span class="skill-dot on"></span><span class="skill-dot on"></span><span class="skill-dot on"></span></div>
+              <div class="skill-track"><div class="skill-fill" data-pct="100"></div></div>
             </div>
             <div class="skill-row">
               <span class="skill-name">Security Hub</span>
-              <div class="skill-dots"><span class="skill-dot on"></span><span class="skill-dot on"></span><span class="skill-dot on"></span><span class="skill-dot"></span><span class="skill-dot"></span></div>
+              <div class="skill-track"><div class="skill-fill" data-pct="65"></div></div>
             </div>
           </div>
         </div>
 
-        <!-- Cloud Infrastructure -->
-        <div class="skill-category fade-in d2">
+        <!-- Cloud Infrastructure — green -->
+        <div class="skill-category fade-in d2" style="--cat-c:#22c55e;--cat-rgb:34,197,94">
           <h3 class="skill-cat-title">
-            <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2" aria-hidden="true"><rect x="2" y="3" width="20" height="14" rx="2"/><path d="M8 21h8M12 17v4"/></svg>
+            <span class="sct-icon" aria-hidden="true">
+              <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><rect x="2" y="3" width="20" height="14" rx="2"/><path d="M8 21h8M12 17v4"/></svg>
+            </span>
             Cloud Infrastructure
           </h3>
           <div class="skill-rows">
             <div class="skill-row">
               <span class="skill-name">Terraform</span>
-              <div class="skill-dots"><span class="skill-dot on"></span><span class="skill-dot on"></span><span class="skill-dot on"></span><span class="skill-dot on"></span><span class="skill-dot on"></span></div>
+              <div class="skill-track"><div class="skill-fill" data-pct="100"></div></div>
             </div>
             <div class="skill-row">
               <span class="skill-name">Lambda</span>
-              <div class="skill-dots"><span class="skill-dot on"></span><span class="skill-dot on"></span><span class="skill-dot on"></span><span class="skill-dot on"></span><span class="skill-dot on"></span></div>
+              <div class="skill-track"><div class="skill-fill" data-pct="100"></div></div>
             </div>
             <div class="skill-row">
               <span class="skill-name">EventBridge</span>
-              <div class="skill-dots"><span class="skill-dot on"></span><span class="skill-dot on"></span><span class="skill-dot on"></span><span class="skill-dot on"></span><span class="skill-dot on"></span></div>
+              <div class="skill-track"><div class="skill-fill" data-pct="100"></div></div>
             </div>
             <div class="skill-row">
               <span class="skill-name">VPC / NACLs</span>
-              <div class="skill-dots"><span class="skill-dot on"></span><span class="skill-dot on"></span><span class="skill-dot on"></span><span class="skill-dot on"></span><span class="skill-dot on"></span></div>
+              <div class="skill-track"><div class="skill-fill" data-pct="100"></div></div>
             </div>
             <div class="skill-row">
               <span class="skill-name">API Gateway</span>
-              <div class="skill-dots"><span class="skill-dot on"></span><span class="skill-dot on"></span><span class="skill-dot on"></span><span class="skill-dot on"></span><span class="skill-dot"></span></div>
+              <div class="skill-track"><div class="skill-fill" data-pct="82"></div></div>
             </div>
             <div class="skill-row">
               <span class="skill-name">CloudWatch / SNS</span>
-              <div class="skill-dots"><span class="skill-dot on"></span><span class="skill-dot on"></span><span class="skill-dot on"></span><span class="skill-dot on"></span><span class="skill-dot"></span></div>
+              <div class="skill-track"><div class="skill-fill" data-pct="88"></div></div>
             </div>
             <div class="skill-row">
               <span class="skill-name">S3 / EC2</span>
-              <div class="skill-dots"><span class="skill-dot on"></span><span class="skill-dot on"></span><span class="skill-dot on"></span><span class="skill-dot on"></span><span class="skill-dot on"></span></div>
+              <div class="skill-track"><div class="skill-fill" data-pct="100"></div></div>
             </div>
           </div>
         </div>
 
-        <!-- Languages & Testing -->
-        <div class="skill-category fade-in d1">
+        <!-- Languages & Testing — orange -->
+        <div class="skill-category fade-in d1" style="--cat-c:#f0883e;--cat-rgb:240,136,62">
           <h3 class="skill-cat-title">
-            <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2" aria-hidden="true"><polyline points="16 18 22 12 16 6"/><polyline points="8 6 2 12 8 18"/></svg>
+            <span class="sct-icon" aria-hidden="true">
+              <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><polyline points="16 18 22 12 16 6"/><polyline points="8 6 2 12 8 18"/></svg>
+            </span>
             Languages &amp; Testing
           </h3>
           <div class="skill-rows">
             <div class="skill-row">
               <span class="skill-name">Python 3.11</span>
-              <div class="skill-dots"><span class="skill-dot on"></span><span class="skill-dot on"></span><span class="skill-dot on"></span><span class="skill-dot on"></span><span class="skill-dot"></span></div>
+              <div class="skill-track"><div class="skill-fill" data-pct="85"></div></div>
             </div>
             <div class="skill-row">
               <span class="skill-name">pytest</span>
-              <div class="skill-dots"><span class="skill-dot on"></span><span class="skill-dot on"></span><span class="skill-dot on"></span><span class="skill-dot on"></span><span class="skill-dot on"></span></div>
+              <div class="skill-track"><div class="skill-fill" data-pct="100"></div></div>
             </div>
             <div class="skill-row">
               <span class="skill-name">moto (AWS mocking)</span>
-              <div class="skill-dots"><span class="skill-dot on"></span><span class="skill-dot on"></span><span class="skill-dot on"></span><span class="skill-dot on"></span><span class="skill-dot on"></span></div>
+              <div class="skill-track"><div class="skill-fill" data-pct="100"></div></div>
             </div>
             <div class="skill-row">
               <span class="skill-name">boto3</span>
-              <div class="skill-dots"><span class="skill-dot on"></span><span class="skill-dot on"></span><span class="skill-dot on"></span><span class="skill-dot on"></span><span class="skill-dot on"></span></div>
+              <div class="skill-track"><div class="skill-fill" data-pct="100"></div></div>
             </div>
             <div class="skill-row">
               <span class="skill-name">Git / GitHub Actions</span>
-              <div class="skill-dots"><span class="skill-dot on"></span><span class="skill-dot on"></span><span class="skill-dot on"></span><span class="skill-dot on"></span><span class="skill-dot"></span></div>
+              <div class="skill-track"><div class="skill-fill" data-pct="80"></div></div>
             </div>
             <div class="skill-row">
-              <span class="skill-name">bash</span>
-              <div class="skill-dots"><span class="skill-dot on"></span><span class="skill-dot on"></span><span class="skill-dot on"></span><span class="skill-dot"></span><span class="skill-dot"></span></div>
+              <span class="skill-name">Bash</span>
+              <div class="skill-track"><div class="skill-fill" data-pct="65"></div></div>
             </div>
           </div>
         </div>
 
-        <!-- Security Practices -->
-        <div class="skill-category fade-in d2">
+        <!-- Security Practices — purple -->
+        <div class="skill-category fade-in d2" style="--cat-c:#bc8cff;--cat-rgb:188,140,255">
           <h3 class="skill-cat-title">
-            <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2" aria-hidden="true"><circle cx="12" cy="12" r="10"/><line x1="12" y1="8" x2="12" y2="12"/><line x1="12" y1="16" x2="12.01" y2="16"/></svg>
+            <span class="sct-icon" aria-hidden="true">
+              <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><rect x="3" y="11" width="18" height="11" rx="2"/><path d="M7 11V7a5 5 0 0110 0v4"/></svg>
+            </span>
             Security Practices
           </h3>
           <div class="skill-rows">
             <div class="skill-row">
               <span class="skill-name">Threat Detection</span>
-              <div class="skill-dots"><span class="skill-dot on"></span><span class="skill-dot on"></span><span class="skill-dot on"></span><span class="skill-dot on"></span><span class="skill-dot on"></span></div>
+              <div class="skill-track"><div class="skill-fill" data-pct="100"></div></div>
             </div>
             <div class="skill-row">
               <span class="skill-name">Auto-Remediation</span>
-              <div class="skill-dots"><span class="skill-dot on"></span><span class="skill-dot on"></span><span class="skill-dot on"></span><span class="skill-dot on"></span><span class="skill-dot on"></span></div>
+              <div class="skill-track"><div class="skill-fill" data-pct="100"></div></div>
             </div>
             <div class="skill-row">
               <span class="skill-name">Defense in Depth</span>
-              <div class="skill-dots"><span class="skill-dot on"></span><span class="skill-dot on"></span><span class="skill-dot on"></span><span class="skill-dot on"></span><span class="skill-dot on"></span></div>
+              <div class="skill-track"><div class="skill-fill" data-pct="100"></div></div>
             </div>
             <div class="skill-row">
               <span class="skill-name">Least Privilege IAM</span>
-              <div class="skill-dots"><span class="skill-dot on"></span><span class="skill-dot on"></span><span class="skill-dot on"></span><span class="skill-dot on"></span><span class="skill-dot on"></span></div>
+              <div class="skill-track"><div class="skill-fill" data-pct="100"></div></div>
             </div>
             <div class="skill-row">
               <span class="skill-name">Incident Response</span>
-              <div class="skill-dots"><span class="skill-dot on"></span><span class="skill-dot on"></span><span class="skill-dot on"></span><span class="skill-dot on"></span><span class="skill-dot"></span></div>
+              <div class="skill-track"><div class="skill-fill" data-pct="80"></div></div>
             </div>
             <div class="skill-row">
               <span class="skill-name">Vulnerability Mgmt</span>
-              <div class="skill-dots"><span class="skill-dot on"></span><span class="skill-dot on"></span><span class="skill-dot on"></span><span class="skill-dot on"></span><span class="skill-dot"></span></div>
+              <div class="skill-track"><div class="skill-fill" data-pct="82"></div></div>
             </div>
           </div>
         </div>

--- a/portfolio/js/main.js
+++ b/portfolio/js/main.js
@@ -218,23 +218,40 @@ document.addEventListener('DOMContentLoaded', function () {
 function animateCounter(el) {
   var target = parseInt(el.dataset.target, 10);
   var suffix = el.dataset.suffix || '';
-  var dur = 1600, startTime = performance.now();
-  (function step(now) {
-    var p = Math.min((now - startTime) / dur, 1);
+  var dur = 1600;
+  var startTime = null;
+  function step(ts) {
+    if (!startTime) startTime = ts;
+    var p = Math.min((ts - startTime) / dur, 1);
     var eased = 1 - Math.pow(1 - p, 3);
-    el.textContent = Math.floor(eased * target) + (p < 1 ? '' : suffix);
+    el.textContent = Math.round(eased * target) + (p >= 1 ? suffix : '');
     if (p < 1) requestAnimationFrame(step);
-  })(startTime);
+  }
+  requestAnimationFrame(step);
 }
 
 var counterObs = new IntersectionObserver(function (entries) {
   entries.forEach(function (e) {
     if (!e.isIntersecting) return;
-    e.target.querySelectorAll('[data-target]').forEach(animateCounter);
+    animateCounter(e.target);
     counterObs.unobserve(e.target);
   });
-}, { threshold: 0.2 });
+}, { threshold: 0 });
 
-document.querySelectorAll('.stats-row, .metrics-grid').forEach(function (el) {
+document.querySelectorAll('[data-target]').forEach(function (el) {
   counterObs.observe(el);
+});
+
+/* ── Skill bar animation ─────────────────────────────────────── */
+var barObs = new IntersectionObserver(function (entries) {
+  entries.forEach(function (e) {
+    if (!e.isIntersecting) return;
+    var pct = e.target.dataset.pct;
+    if (pct) e.target.style.width = pct + '%';
+    barObs.unobserve(e.target);
+  });
+}, { threshold: 0.1 });
+
+document.querySelectorAll('.skill-fill').forEach(function (el) {
+  barObs.observe(el);
 });


### PR DESCRIPTION
Metrics strip: 5 colour-coded icon cards (cyan/green/orange/purple/blue) with per-card glow, hover lift, accent underline, and sweep animation. Skill matrix: replace static dots with animated progress bars that fill on scroll; each category has a coloured left-border and icon. Counter JS fixed — observe each [data-target] directly with startTime=null RAF pattern so numbers actually count up instead of staying at 0.


Claude-Session: https://claude.ai/code/session_01Bv3qLnk3bb4U3rPD48WCmS